### PR TITLE
Enable public RSPM for R dependency setup

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Setup R Dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          use-public-rspm: true
           extra-packages: |
             any::rcmdcheck
             any::tidyverse


### PR DESCRIPTION
Updating GH action to resolve dependency setup better.