### PR TITLE
Update workflow to render only README RMarkdown files

### DIFF
--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -74,11 +74,11 @@ jobs:
         with:
           extra-packages: any::rmarkdown, local::.
 
-      - name: Render RMarkdown files
+      - name: Render README RMarkdown files
         if: steps.check_rmd.outputs.has_rmd == 'true'
         shell: bash
         run: |
-          RMD_PATH=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.Rmd$' || true)
+          RMD_PATH=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -P '^./README\.Rmd$' || true)
           if [ -n "$RMD_PATH" ]; then
             Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
             echo "RMD_PATH=$RMD_PATH" >> $GITHUB_ENV


### PR DESCRIPTION
Fix to GH action Rmarkdown render. It needs to target README.Rmd only. The vignettes/BRcore-vignette.Rmd is handled manually before releases.