### PR TITLE
Release/v2.0.1 (dev)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^CRAN-SUBMISSION$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^docs$
 ^pkgdown$
 ^CRAN-SUBMISSION$
+^tests/testthat/test_sets/test_vignette_data\.rda$

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to BRCore! This document provides ge
 
 ## Table of Contents
 
--   [Getting Help]
+-   [Getting Help](#getting-help)
 -   [Code of Conduct](#code-of-conduct)
 -   [Getting Started](#getting-started)
 -   [How to Contribute](#how-to-contribute)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,14 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches:
-      - "release/**"
-      - "patch*"
-      - "feature*"
-      - "feature/**"
-      - "patch/**"
-      - "main"
+
   pull_request:
     branches:
       - main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Authors@R: c(
     person("Great Lakes Bioenergy Research Center", 
            role = c("cph", "fnd"))
   )
-Description: This package provides a unified framework for identification and ecological interpretation of core microbiomes across time and space, enhancing robustness and reproducibility in microbiome data analysis.
+Description: A unified framework for identification and ecological interpretation of core microbiomes across time and space, enhancing robustness and reproducibility in microbiome data analysis.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Language: en
@@ -65,5 +65,5 @@ Depends:
     R (>= 4.4)
 LazyData: true
 VignetteBuilder: knitr
-URL: https://github.com/germs-lab/BRCore, http://www.germslab.org/BRCore/
+URL: https://github.com/germs-lab/BRCore, https://www.germslab.org/BRCore/
 BugReports: https://github.com/germs-lab/BRCore/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BRCore
 Title: Unified Framework for Identification and Ecological Interpretation of Microbial Data from Bioenergy Research Centers
-Version: 2.0.0
+Version: 2.0.1
 Authors@R: c(
     person("Bolívar", "Aponte Rolón",
            email = "bolaponte@pm.me", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# BRCore 2.0.0
+# BRCore 2.0.1
+Date: 2026-04-25
+
+* Resubmission to CRAN to address auto-check issues on Debian and Windows.
+
+BRCore 2.0.0
 Date: 2026-04-24
 
 ## Breaking Changes

--- a/R/fit_neutral_model.R
+++ b/R/fit_neutral_model.R
@@ -73,10 +73,10 @@
 #' @importFrom Hmisc binconf
 #' @export
 fit_neutral_model <- function(
-        otu_table,
-        core_set,
-        abundance_occupancy) {
-    
+  otu_table,
+  core_set,
+  abundance_occupancy
+) {
   # input checks ----
   if (!is.matrix(otu_table) && !is.data.frame(otu_table)) {
     cli::cli_abort(

--- a/README.Rmd
+++ b/README.Rmd
@@ -133,8 +133,8 @@ vignette("BRCore-vignette", package = "BRCore")
 
 ## Contributing
 
-Contributions to BRCore are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute.
+Contributions to BRCore are welcome! Please see the [CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/CONTRIBUTING.md)file for guidelines on how to contribute.
 
 ## Code of Conduct
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/germs-lab/BRCore/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/README.Rmd
+++ b/README.Rmd
@@ -133,8 +133,8 @@ vignette("BRCore-vignette", package = "BRCore")
 
 ## Contributing
 
-Contributions to BRCore are welcome! Please see the [CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/CONTRIBUTING.md)file for guidelines on how to contribute.
+Contributions to BRCore are welcome! Please see the [CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/.github/CONTRIBUTING.md) file for guidelines on how to contribute.
 
 ## Code of Conduct
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/germs-lab/BRCore/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/germs-lab/BRCore/blob/main/.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ install.packages("BRCore")
 
 Install the *development* version of BRCore from GitHub with:
 
+Install the *development* version of BRCore from GitHub with:
+
 ``` r
 # install.packages("pak")
 pak::pak("germs-lab/BRCore")
@@ -133,11 +135,11 @@ vignette("BRCore-vignette", package = "BRCore")
 ## Contributing
 
 Contributions to BRCore are welcome! Please see the
-[CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to
-contribute.
+[CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/CONTRIBUTING.md)file
+for guidelines on how to contribute.
 
 ## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of
-Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree
-to abide by its terms.
+Conduct](https://github.com/germs-lab/BRCore/blob/main/CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ vignette("BRCore-vignette", package = "BRCore")
 ## Contributing
 
 Contributions to BRCore are welcome! Please see the
-[CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/CONTRIBUTING.md)file
-for guidelines on how to contribute.
+[CONTRIBUTING.md](https://github.com/germs-lab/BRCore/blob/main/.github/CONTRIBUTING.md)
+file for guidelines on how to contribute.
 
 ## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of
-Conduct](https://github.com/germs-lab/BRCore/blob/main/CODE_OF_CONDUCT.md).
+Conduct](https://github.com/germs-lab/BRCore/blob/main/.github/CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,43 @@
-## R CMD check results
+## R CMD check results (v2.0.1 resubmission)
 
-0 errors | 0 warnings | 0 note
+0 errors | 0 warnings | 2 notes
 
-* This is a new release.
+### Notes
+
+1. **CRAN incoming feasibility**:
+   - `New submission`: Expected for new submission or re-submission.
+   - `Running aspell failed`: The `aspell` English dictionary is unavailable in
+     the local check environment (`/usr/lib/aspell-0.60/en_US`). This is a
+     local environment issue and does not affect the package.
+
+2. **HTML version of manual**: `V8` package unavailable in the local check
+   environment, skipping math rendering check. This is a local environment
+   issue.
+
+### Resubmission notes (v2.0.1)
+
+This is a resubmission of v2.0.0, which was rejected by the CRAN auto-check
+service (win-builder, r-devel-windows-x86_64). The following issues were
+identified and resolved:
+
+1. **URL in DESCRIPTION**: Changed `http://` to `https://` for the package
+   website URL.
+
+2. **Description field**: Reworded to not start with "This package" per CRAN
+   policy.
+
+3. **Possibly misspelled words** (`BRCore`, `Bioenergy`, `microbiome`, and `microbiomes`): These are intentional. `BRCore` is the package name and `Bioenergy` , `microbiome`, and `microbiomes` are domain-specific terms.
+
+4. **Invalid file URIs in README.md**: Relative links to `CONTRIBUTING.md` and
+   `CODE_OF_CONDUCT.md` replaced with full GitHub URLs.
+
+### win-builder notes
+
+The win-builder (r-devel-windows-x86_64) reported errors for missing packages
+(`stringi`, `jsonlite`, `xfun`, `Formula`). These are indirect dependencies of
+declared imports (`phyloseq`, `Hmisc`, `knitr`) that were absent in the
+win-builder guest environment. The CRAN incoming checks on both Windows and
+Debian passed with only NOTEs, confirming these are not direct imports in
+package code.
+
+* This is a new submission to CRAN.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -3,10 +3,17 @@
 rda_path <- test_path("test_sets/test_vignette_data.rda")
 
 # Only regenerate if the .rda is missing or if running on CI
-if (!file.exists(rda_path)) {
-  source(test_path("test_sets/regenerate_test_data.R"))
+is_check <- nzchar(Sys.getenv("_R_CHECK_PACKAGE_NAME_"))
+is_not_cran <- identical(Sys.getenv("NOT_CRAN"), "true")
+
+# Does not regenerate on CRAN or during R CMD check, but does regenerate during devtools::test() if the .rda is missing
+if (is_not_cran && !is_check) {
+  if (!file.exists(rda_path)) {
+    source(test_path("test_sets/regenerate_test_data.R"))
+  }
 }
 
+# Regenerate test data if running on CI
 if (nzchar(Sys.getenv("CI"))) {
   rda_path <- file.path(
     tempdir(),

--- a/tests/testthat/test-vignette-workflow.R
+++ b/tests/testthat/test-vignette-workflow.R
@@ -6,6 +6,10 @@ test_that("1: Vignette test data structures are valid", {
     "brcore_test_data_path",
     default = test_path("test_sets/test_vignette_data.rda")
   )
+  skip_if_not(
+    file.exists(rda_path),
+    "Test data file not available for testing in this environment: CRAN or R CMD check"
+  )
   load(rda_path)
 
   # Test: Rarefied OTU table is correctly structured and has expected properties
@@ -81,6 +85,10 @@ test_that("2: Vignette workflow produces consistent results", {
   rda_path <- getOption(
     "brcore_test_data_path",
     default = test_path("test_sets/test_vignette_data.rda")
+  )
+  skip_if_not(
+    file.exists(rda_path),
+    "Test data file not available for testing in this environment: CRAN or R CMD check"
   )
   load(rda_path)
 
@@ -264,6 +272,10 @@ test_that("3: Vignette core distribution plots are consistent", {
     "brcore_test_data_path",
     default = test_path("test_sets/test_vignette_data.rda")
   )
+  skip_if_not(
+    file.exists(rda_path),
+    "Test data file not available for testing in this environment: CRAN or R CMD check"
+  )
   load(rda_path)
 
   # Recreate necessary objects for plotting
@@ -399,6 +411,10 @@ test_that("4: Vignette neutral model fitting is consistent", {
   rda_path <- getOption(
     "brcore_test_data_path",
     default = test_path("test_sets/test_vignette_data.rda")
+  )
+  skip_if_not(
+    file.exists(rda_path),
+    "Test data file not available for testing in this environment: CRAN or R CMD check"
   )
   load(rda_path)
 

--- a/vignettes/BRCore-vignette.R
+++ b/vignettes/BRCore-vignette.R
@@ -16,7 +16,7 @@ options(cli.progress_show_after = Inf) # Disable progress bar for cleaner output
 ##   padding: 10px;
 ##   margin: 15px 0;
 ## }
-## 
+##
 ## h1, .h1 {
 ##     margin-top: 84px;
 ##     margin-bottom: 42px;
@@ -25,7 +25,7 @@ options(cli.progress_show_after = Inf) # Disable progress bar for cleaner output
 ##     margin-top: 42px;
 ##     margin-bottom: 21px;
 ## }
-## 
+##
 ## p.caption {
 ##     font-size: 1em;
 ##     font-style: italic;
@@ -106,14 +106,13 @@ bcse_core_multi <- identify_core(
   seed = 2134
 )
 
-# With a single iteration 
+# With a single iteration
 # bcse_core_single <- identify_core(
 #   physeq_obj = bcse_rare_single,
 #   priority_var = "Crop",
 #   increase_value = 0.02,
 #   seed = 2134
 # )
-
 
 ## ----check the identified core, echo=TRUE---------------------------
 str(bcse_core_multi)
@@ -131,7 +130,6 @@ print(bcse_identified_core)
 
 
 ## ----plot abundance occupany and increase core set, echo=TRUE-------
-
 
 ## ----fig4_plot_increase, echo=TRUE, fig.cap="Figure 4: Abundance-occupancy distribution for the 'bcse' dataset. The core ASV/OTUs identified by the last 2% increase method are highlighted in red."----
 plot_abund_occ_increase <- plot_abundance_occupancy(
@@ -163,8 +161,6 @@ print(plot_core_dist_bar)
 
 
 ## ----plot_type line-------------------------------------------------
-
-
 
 ## ----fig7_plot_type_line, echo=TRUE, fig.width=7, fig.height=10, fig.cap="Figure 7: Occupancy of core ASV/OTUs across the 'Crop' variable. Each point represents the average occupancy of core ASV/OTUs in samples belonging to each level of the 'Crop' variable. A line plot is better than a bar plot but still not ideal for this many variable levels."----
 plot_core_dist_line <- plot_core_distribution(
@@ -212,8 +208,6 @@ bcse_core_multi$metadata <- bcse_core_multi$metadata %>%
 
 ## ----plot_type heatmap----------------------------------------------
 
-
-
 ## ----fig8_plot_type_heatmap, echo=TRUE, fig.cap="Figure 8: Occupancy of core ASV/OTUs across the 'Crop' variable. Each cell represents the average occupancy of core ASV/OTUs in samples belonging to each level of the 'Crop' variable. A heatmap is more compact and shows well enough the average occupancy across samples in each variable level."----
 plot_core_dist_heatmap <- plot_core_distribution(
   core_result = bcse_core_multi,
@@ -252,4 +246,3 @@ bcse_core_multi_iter1 <- identify_core(
   abundance_weight = 0,
   seed = 2135
 )
-


### PR DESCRIPTION
 ## Bump version to `v2.0.1` after resubmission to CRAN to address auto-check issues on Debian and Windows.
**Duplicate of #101 to update branch.**

The main issues were in the DESCRIPTION (duplicate comments, package details, etc.). This also changes testing, since the package was too large because `v2.0.0` shipped with `tests/testthat/test_sets/test_vignette_data.rda`.  I made some changes to the `tests/testthat/test-vignette-workflow.R and tests/testthat/setup.R`, so it runs on GH with the full tests, and on CRAN and locally with partial tests (it excludes the `tests/testthat/test-vignette-workflow.R`) when performing` devtools::check()`. To test locally, we must use `devtools::tests()`.